### PR TITLE
fix: Excluding events and some basic models from coverage

### DIFF
--- a/Luxoria.App/Luxoria.Modules/EventBus.cs
+++ b/Luxoria.App/Luxoria.Modules/EventBus.cs
@@ -1,8 +1,4 @@
 ﻿using Luxoria.Modules.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Luxoria.Modules
 {

--- a/Luxoria.App/Luxoria.Modules/Models/Events/CollectionUpdatedEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/CollectionUpdatedEvent.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace Luxoria.Modules.Models.Events
 {
+    [ExcludeFromCodeCoverage]
     public class CollectionUpdatedEvent
     {
         /// <summary>

--- a/Luxoria.App/Luxoria.Modules/Models/Events/CollectionUpdatedEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/CollectionUpdatedEvent.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Luxoria.Modules.Models.Events
 {

--- a/Luxoria.App/Luxoria.Modules/Models/Events/ImageUpdatedEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/ImageUpdatedEvent.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Luxoria.Modules.Models.Events
 {
+    [ExcludeFromCodeCoverage]
     public class ImageUpdatedEvent
     {
         public string ImagePath { get; }

--- a/Luxoria.App/Luxoria.Modules/Models/Events/ImageUpdatedEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/ImageUpdatedEvent.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Luxoria.Modules.Models.Events
 {

--- a/Luxoria.App/Luxoria.Modules/Models/Events/LogEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/LogEvent.cs
@@ -1,5 +1,8 @@
-﻿namespace Luxoria.Modules.Models.Events
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Luxoria.Modules.Models.Events
 {
+    [ExcludeFromCodeCoverage]
     public class LogEvent
     {
         public string Message { get; }

--- a/Luxoria.App/Luxoria.Modules/Models/Events/OpenCollectionEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/OpenCollectionEvent.cs
@@ -1,8 +1,11 @@
-﻿namespace Luxoria.Modules.Models.Events;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Luxoria.Modules.Models.Events;
 
 /// <summary>
 /// Represents an event triggered when a collection is opened.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public class OpenCollectionEvent
 {
     // *** Properties ***

--- a/Luxoria.App/Luxoria.Modules/Models/Events/TextInputEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/TextInputEvent.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Luxoria.Modules.Models.Events
 {
+    [ExcludeFromCodeCoverage]
     public class TextInputEvent
     {
         public string Text { get; }

--- a/Luxoria.App/Luxoria.Modules/Models/Events/TextInputEvent.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/Events/TextInputEvent.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Luxoria.Modules.Models.Events
 {

--- a/Luxoria.App/Luxoria.Modules/Models/FileExtension.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/FileExtension.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Luxoria.Modules.Models
+﻿namespace Luxoria.Modules.Models
 {
     /// <summary>
     /// Represents a file extension.

--- a/Luxoria.App/Luxoria.Modules/Models/LuxAction.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/LuxAction.cs
@@ -1,43 +1,45 @@
-﻿namespace Luxoria.Modules.Models
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Luxoria.Modules.Models;
+
+/// <summary>
+/// Represents an action associated with a tool in the Luxoria application.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LuxAction
 {
     /// <summary>
-    /// Represents an action associated with a tool in the Luxoria application.
+    /// Gets the unique identifier for the action.
     /// </summary>
-    public class LuxAction
+    public Guid Id { get; private set; }
+
+    /// <summary>
+    /// Gets the unique identifier for the associated tool.
+    /// </summary>
+    public Guid ToolId { get; private set; }
+
+    /// <summary>
+    /// Gets the parameters associated with the action.
+    /// </summary>
+    public List<string> Parameters { get; private set; }
+
+    /// <summary>
+    /// Gets the arguments associated with the action.
+    /// </summary>
+    public List<string> Args { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LuxAction"/> class.
+    /// </summary>
+    /// <param name="id">The unique identifier for the action.</param>
+    /// <param name="toolId">The unique identifier for the associated tool.</param>
+    /// <param name="parameters">The parameters associated with the action.</param>
+    /// <param name="args">The arguments associated with the action.</param>
+    public LuxAction(Guid id, Guid toolId, List<string> parameters, List<string> args)
     {
-        /// <summary>
-        /// Gets the unique identifier for the action.
-        /// </summary>
-        public Guid Id { get; private set; }
-
-        /// <summary>
-        /// Gets the unique identifier for the associated tool.
-        /// </summary>
-        public Guid ToolId { get; private set; }
-
-        /// <summary>
-        /// Gets the parameters associated with the action.
-        /// </summary>
-        public List<string> Parameters { get; private set; }
-
-        /// <summary>
-        /// Gets the arguments associated with the action.
-        /// </summary>
-        public List<string> Args { get; private set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LuxAction"/> class.
-        /// </summary>
-        /// <param name="id">The unique identifier for the action.</param>
-        /// <param name="toolId">The unique identifier for the associated tool.</param>
-        /// <param name="parameters">The parameters associated with the action.</param>
-        /// <param name="args">The arguments associated with the action.</param>
-        public LuxAction(Guid id, Guid toolId, List<string> parameters, List<string> args)
-        {
-            Id = id;
-            ToolId = toolId;
-            Parameters = parameters ?? new List<string>();
-            Args = args ?? new List<string>();
-        }
+        Id = id;
+        ToolId = toolId;
+        Parameters = parameters ?? new List<string>();
+        Args = args ?? new List<string>();
     }
 }

--- a/Luxoria.App/Luxoria.Modules/Models/LuxAsset.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/LuxAsset.cs
@@ -1,31 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 
-namespace Luxoria.Modules.Models
+namespace Luxoria.Modules.Models;
+
+/// <summary>
+/// Contains the properties of an asset in the Luxoria application.
+/// Data -> ImageData
+/// ConfigFile -> LuxCfg
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LuxAsset
 {
     /// <summary>
-    /// Contains the properties of an asset in the Luxoria application.
-    /// Data -> ImageData
-    /// ConfigFile -> LuxCfg
+    /// Gets the unique identifier for the asset.
     /// </summary>
-    public class LuxAsset
-    {
-        /// <summary>
-        /// Gets the unique identifier for the asset.
-        /// </summary>
-        public Guid Id => MetaData.Id;
+    public Guid Id => MetaData.Id;
 
-        /// <summary>
-        /// Contains the properties of the asset.
-        /// </summary>
-        public required LuxCfg MetaData { get; init; }
+    /// <summary>
+    /// Contains the properties of the asset.
+    /// </summary>
+    public required LuxCfg MetaData { get; init; }
 
-        /// <summary>
-        /// Contains the data of the asset.
-        /// </summary>
-        public required ImageData Data { get; init; }
-    }
+    /// <summary>
+    /// Contains the data of the asset.
+    /// </summary>
+    public required ImageData Data { get; init; }
 }

--- a/Luxoria.App/Luxoria.Modules/Models/LuxCfg.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/LuxCfg.cs
@@ -1,94 +1,93 @@
-﻿using System.Collections.Generic;
-using Luxoria.Modules.Models;
+﻿using System.Diagnostics.CodeAnalysis;
 
-namespace Luxoria.Modules.Models
+namespace Luxoria.Modules.Models;
+
+/// <summary>
+/// Represents a picture with its properties and associated actions and versioning.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LuxCfg
 {
     /// <summary>
-    /// Represents a picture with its properties and associated actions and versioning.
+    /// Gets the configuration version of the Luxoria application.
     /// </summary>
-    public class LuxCfg
+    public string Version { get; private set; }
+
+    /// <summary>
+    /// Gets the unique identifier for the picture.
+    /// </summary>
+    public Guid Id { get; private set; }
+
+    /// <summary>
+    /// Gets the name of the picture.
+    /// </summary>
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Gets the file name of the picture.
+    /// </summary>
+    public string FileName { get; private set; }
+
+    /// <summary>
+    /// Gets the description of the picture.
+    /// </summary>
+    public string Description { get; private set; }
+
+    /// <summary>
+    /// Gets the file extension of the picture.
+    /// </summary>
+    public FileExtension Extension { get; private set; }
+
+    /// <summary>ff
+    /// Gets the full name of the picture, combining the name and extension.
+    /// </summary>
+    public string FullName => FileName;
+
+    /// <summary>
+    /// Gets the list of actions associated with the picture.
+    /// </summary>
+    public List<LuxAction> Actions { get; private set; }
+
+    /// <summary>
+    /// Gets the list of versions associated with the picture.
+    /// </summary>
+    public List<LuxVersion> Versionning { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Picture"/> class.
+    /// </summary>
+    /// <param name="version">The configuration version of Luxoria.</param>
+    /// <param name="name">The name of the picture.</param>
+    /// <param name="fileName">The file name of the picture.</param>
+    /// <param name="description">The description of the picture.</param>
+    /// <param name="extension">The file extension of the picture.</param>
+    /// <param name="actions">The list of actions associated with the picture.</param>
+    /// <param name="versionning">The list of versions associated with the picture.</param>
+    public LuxCfg(string version, Guid fileUuid, string name, string fileName, string description, FileExtension extension)
     {
-        /// <summary>
-        /// Gets the configuration version of the Luxoria application.
-        /// </summary>
-        public string Version { get; private set; }
+        Version = version;
 
-        /// <summary>
-        /// Gets the unique identifier for the picture.
-        /// </summary>
-        public Guid Id { get; private set; }
+        Id = fileUuid;
+        Name = name;
+        FileName = fileName;
+        Description = description;
+        Extension = extension;
+        Actions = new List<LuxAction>();
+        Versionning = new List<LuxVersion>();
+    }
 
-        /// <summary>
-        /// Gets the name of the picture.
-        /// </summary>
-        public string Name { get; private set; }
-
-        /// <summary>
-        /// Gets the file name of the picture.
-        /// </summary>
-        public string FileName { get; private set; }
-
-        /// <summary>
-        /// Gets the description of the picture.
-        /// </summary>
-        public string Description { get; private set; }
-
-        /// <summary>
-        /// Gets the file extension of the picture.
-        /// </summary>
-        public FileExtension Extension { get; private set; }
-
-        /// <summary>ff
-        /// Gets the full name of the picture, combining the name and extension.
-        /// </summary>
-        public string FullName => FileName;
-
-        /// <summary>
-        /// Gets the list of actions associated with the picture.
-        /// </summary>
-        public List<LuxAction> Actions { get; private set; }
-
-        /// <summary>
-        /// Gets the list of versions associated with the picture.
-        /// </summary>
-        public List<LuxVersion> Versionning { get; private set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Picture"/> class.
-        /// </summary>
-        /// <param name="version">The configuration version of Luxoria.</param>
-        /// <param name="name">The name of the picture.</param>
-        /// <param name="fileName">The file name of the picture.</param>
-        /// <param name="description">The description of the picture.</param>
-        /// <param name="extension">The file extension of the picture.</param>
-        /// <param name="actions">The list of actions associated with the picture.</param>
-        /// <param name="versionning">The list of versions associated with the picture.</param>
-        public LuxCfg(string version, Guid fileUuid, string name, string fileName, string description, FileExtension extension)
-        {
-            Version = version;
-
-            Id = fileUuid;
-            Name = name;
-            FileName = fileName;
-            Description = description;
-            Extension = extension;
-            Actions = new List<LuxAction>();
-            Versionning = new List<LuxVersion>();
-        }
-
-        /// <summary>
-        /// Public model 'Asset interface'
-        /// </summary>
-        public class AssetInterface
-        {
-            // File name
-            public required string FileName { get; set; }   
-            // Relative file path
-            public required string RelativeFilePath { get; set; }
-            // Related Luxoria Config Id
-            public required Guid LuxCfgId { get; set; }
-            // File hash (SHA-256)
-            public required string Hash { get; set; }
-        }
+    /// <summary>
+    /// Public model 'Asset interface'
+    /// </summary>
+    public class AssetInterface
+    {
+        // File name
+        public required string FileName { get; set; }
+        // Relative file path
+        public required string RelativeFilePath { get; set; }
+        // Related Luxoria Config Id
+        public required Guid LuxCfgId { get; set; }
+        // File hash (SHA-256)
+        public required string Hash { get; set; }
     }
 }

--- a/Luxoria.App/Luxoria.Modules/Models/LuxVersion.cs
+++ b/Luxoria.App/Luxoria.Modules/Models/LuxVersion.cs
@@ -1,4 +1,8 @@
-﻿namespace Luxoria.Modules.Models;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Luxoria.Modules.Models;
+
+[ExcludeFromCodeCoverage]
 public class LuxVersion
 {
     /// <summary>

--- a/Luxoria.App/Luxoria.Modules/ModuleContext.cs
+++ b/Luxoria.App/Luxoria.Modules/ModuleContext.cs
@@ -1,6 +1,5 @@
 ﻿using Luxoria.Modules.Interfaces;
 using Luxoria.Modules.Models;
-using System;
 
 namespace Luxoria.Modules
 {


### PR DESCRIPTION
# PR: Exclude Simple Models from Test Coverage

This update excludes models that contain no logic from test coverage. These basic models primarily serve as data containers, and including them in coverage metrics does not add significant value.