### PR TITLE
fix: Disabling some unuseful tests 

### DIFF
--- a/Luxoria.App/Luxoria.Modules.Tests/FileExtensionHelperTests.cs
+++ b/Luxoria.App/Luxoria.Modules.Tests/FileExtensionHelperTests.cs
@@ -1,0 +1,40 @@
+﻿using Luxoria.Modules.Models;
+using Luxoria.Modules.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Luxoria.Modueles.Tests
+{
+    public class FileExtensionHelperTests
+    {
+        [Fact]
+        public void GetFileExtension_ReturnsFileExtension()
+        {
+            // Act
+            FileExtension result = FileExtensionHelper.ConvertToEnum(".png");
+            // Assert
+            Assert.Equal(FileExtension.PNG, result);
+        }
+
+        [Fact]
+        public void GetFileExtension_ReturnsUnknown()
+        {
+            // Act
+            FileExtension result = FileExtensionHelper.ConvertToEnum(".abc");
+            // Assert
+            Assert.Equal(FileExtension.UNKNOWN, result);
+        }
+
+        [Fact]
+        public void GetFileExtension_ConvertEnumToString()
+        {
+            // Act
+            string result = FileExtensionHelper.ConvertToString(FileExtension.PNG);
+            // Assert
+            Assert.Equal("PNG", result);
+        }
+    }
+}

--- a/Luxoria.App/Luxoria.Modules.Tests/ManifestTests.cs
+++ b/Luxoria.App/Luxoria.Modules.Tests/ManifestTests.cs
@@ -1,0 +1,37 @@
+﻿using LuxImport.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Luxoria.Modueles.Tests;
+
+public class ManifestTests
+{
+    [Fact]
+    public void CreateManifest_ReturnsManifest()
+    {
+        // Act
+        Manifest result = new("Test", "This is a test manifest", "1.0.0", new("1.0"));
+
+        // Check the properties
+        DateTime createdAt = result.CreatedAt;
+        DateTime updatedAt = result.UpdatedAt;
+
+        // Assert
+        Assert.Equal("Test", result.Name);
+        Assert.Equal("This is a test manifest", result.Description);
+        Assert.Equal("1.0.0", result.Version);
+        Assert.Equal("1.0", result.Luxoria.Version);
+
+        // Verify the CreatedAt and UpdatedAt properties
+        Assert.Equal(result.CreatedAt, createdAt);
+
+        // Change a property
+        result.Name = "Test 2";
+
+        // Verify the UpdatedAt property
+        Assert.NotEqual(result.UpdatedAt, updatedAt);
+    }
+}


### PR DESCRIPTION
# PR: Exclude Simple Models from Test Coverage
This update excludes models that contain no logic from test coverage. These basic models primarily serve as data containers, and including them in coverage metrics does not add significant value.