### PR TITLE
Corrects image upscaling and cropping

### DIFF
--- a/Modules/LuxEditor/LuxEditor/Components/Editor.xaml.cs
+++ b/Modules/LuxEditor/LuxEditor/Components/Editor.xaml.cs
@@ -834,7 +834,7 @@ namespace LuxEditor.Components
                     var prev = await RenderAsync(CurrentImage.PreviewBitmap);
                     CurrentImage.EditedPreviewBitmap = prev;
                     var upscaled = ImageProcessingManager.Upscale(prev,
-                                                                  CurrentImage.OriginalBitmap.Height,
+                                                                  (int)CurrentImage.Crop.Height,
                                                                   true);
                     OnEditorImageUpdated?.Invoke(upscaled);
                 }
@@ -947,6 +947,13 @@ namespace LuxEditor.Components
         {
             if (CurrentImage == null) return src;
             var box = CurrentImage.Crop;
+            if (src != CurrentImage.OriginalBitmap)
+            {
+                float sx = (float)src.Width / CurrentImage.OriginalBitmap.Width;
+                float sy = (float)src.Height / CurrentImage.OriginalBitmap.Height;
+                box = CropProcessor.Scale(box, sx, sy);
+                
+            }
             return CropProcessor.Apply(src, box);
         }
 

--- a/Modules/LuxEditor/LuxEditor/Logic/CropProcessor.cs
+++ b/Modules/LuxEditor/LuxEditor/Logic/CropProcessor.cs
@@ -16,7 +16,11 @@ namespace LuxEditor.Logic
         {
             int w = (int)MathF.Round(box.Width);
             int h = (int)MathF.Round(box.Height);
-            if (w <= 0 || h <= 0) return src.Copy();
+            if (w <= 0 || h <= 0) return src;
+            if (box.X < 0 || box.Y < 0 || box.X + box.Width > src.Width || box.Y + box.Height > src.Height)
+            {
+                return src;
+            }
 
             var info = new SKImageInfo(w, h, src.ColorType, src.AlphaType, src.ColorSpace);
             var dst = new SKBitmap(info);
@@ -40,21 +44,20 @@ namespace LuxEditor.Logic
 
             surface.ReadPixels(dst.Info, dst.GetPixels(), dst.RowBytes, 0, 0);
 
-            Debug.WriteLine("Box: X:" + box.X + " Y: " + box.Y + " Width: " + box.Width + " Height: " + box.Height + " Angle: " + box.Angle);
-
+            Debug.WriteLine("CropProcessor.Apply: dst: " + dst.Width + "x" + dst.Height);
             return dst;
         }
 
         /// <summary>
         /// Return a copy of <paramref name="box"/> scaled by <paramref name="sx"/> and <paramref name="sy"/>.
         /// </summary>
-        //public static CropController.CropBox Scale(CropController.CropBox box, float sx, float sy) => new()
-        //{
-        //    X = box.X * sx,
-        //    Y = box.Y * sy,
-        //    Width = box.Width * sx,
-        //    Height = box.Height * sy,
-        //    Angle = box.Angle
-        //};
+        public static CropController.CropBox Scale(CropController.CropBox box, float sx, float sy) => new()
+        {
+            X = box.X * sx,
+            Y = box.Y * sy,
+            Width = box.Width * sx,
+            Height = box.Height * sy,
+            Angle = box.Angle
+        };
     }
 }

--- a/Modules/LuxEditor/LuxEditor/LuxEditor.cs
+++ b/Modules/LuxEditor/LuxEditor/LuxEditor.cs
@@ -155,7 +155,6 @@ namespace LuxEditor
                     {
                         ThumbnailBitmap = ImageProcessingManager.GeneratePreview(asset.Data.Bitmap, 200),
                         PreviewBitmap = ImageProcessingManager.GeneratePreview(asset.Data.Bitmap, 500),
-                        MediumBitmap = ImageProcessingManager.GenerateMediumResolution(asset.Data.Bitmap)
                     }
                 );
             }

--- a/Modules/LuxEditor/LuxEditor/Models/EditableImage.cs
+++ b/Modules/LuxEditor/LuxEditor/Models/EditableImage.cs
@@ -20,7 +20,6 @@ namespace LuxEditor.Models
         public string FileName { get; }
         public SKBitmap OriginalBitmap { get; }
         public SKBitmap? ThumbnailBitmap { get; set; }
-        public SKBitmap? MediumBitmap { get; set; }
         public SKBitmap? PreviewBitmap { get; set; }
         public SKBitmap EditedBitmap { get; set; }
         public SKBitmap EditedPreviewBitmap { get; set; }


### PR DESCRIPTION
**Name:** `Luxoria - Pull Request`  
**Title:** `[LDA] - (Editor) fix: Image blinking due to upscaling with cropbox`  
**Assignees:**  @epi-noahg 

---

### **Description**

Fixes an issue where upscaling used the original image height instead of the cropped height.

Ensures correct cropping by scaling the crop box when the source bitmap isn't the original.

Adds input validation for `CropProcessor.Apply` to handle edge cases where crop dimensions or position are invalid.

Removes unused `MediumBitmap` property.

---

### **Checklist**

- [x] My code adheres to the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, especially in areas that might be unclear.
- [x] I have added or updated relevant documentation (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] All new and existing tests pass.
- [x] I have checked that my PR targets the `develop` branch.
- [x] My PR title follows the [conventional commits](https://www.conventionalcommits.org/) format.

---

### **Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (non-breaking changes to improve code quality)

---

### **Related Issues**

Fixes #145 

---

### **How Has This Been Tested?**

---

### **Screenshots (If Applicable)**

---

### **Additional Context**

---